### PR TITLE
add extra grounded check

### DIFF
--- a/BunnyHopMaster/Assets/Scripts/Player/PlayerMovement.cs
+++ b/BunnyHopMaster/Assets/Scripts/Player/PlayerMovement.cs
@@ -120,7 +120,7 @@ public class PlayerMovement : MonoBehaviour
             .OrderBy(hit => hit.distance)
             .Where(hit => !hit.collider.isTrigger)
             .Where(hit => !Physics.GetIgnoreCollision(hit.collider, myCollider))
-            .Where(hit => hit.point.y < transform.position.y);
+            .Where(hit => hit.point.y < transform.position.y && hit.point != Vector3.zero);
 
         grounded = validHits.Count() > 0;
 
@@ -362,7 +362,7 @@ public class PlayerMovement : MonoBehaviour
 
                 Vector3 depenetrationVector = dir * dist; // The vector needed to get outside of the collision
 
-                Debug.Log("depen: " + depenetrationVector.ToString("F5") + " proj " + Vector3.Project(newVelocity, -dir).ToString("F5"));
+                Debug.Log("depen: " + depenetrationVector.ToString("F8") + " proj " + Vector3.Project(newVelocity, -dir).ToString("F5"));
 
                 if (!surfing)
                 {


### PR DESCRIPTION
Physics.boxcastall returns Vector3.zero for the hit point if the collider is inside of the collider before the sweep starts