### PR TITLE
Feature/hotkey to toggle ui

### DIFF
--- a/JumpingJax/Assets/Scripts/Player/PlayerConstants.cs
+++ b/JumpingJax/Assets/Scripts/Player/PlayerConstants.cs
@@ -79,6 +79,8 @@ public static class PlayerConstants
     public static KeyCode WinMenu_RetryLevel = KeyCode.R;
     public static KeyCode WinMenu_MainMenu = KeyCode.Q;
 
+    public static KeyCode Modifier = KeyCode.LeftAlt;
+    public static KeyCode InGameUI = KeyCode.Z; 
 
 
     // Game Constants

--- a/JumpingJax/Assets/Scripts/UI/InGameUI.cs
+++ b/JumpingJax/Assets/Scripts/UI/InGameUI.cs
@@ -66,7 +66,10 @@ public class InGameUI : MonoBehaviour
     {
         foreach (Transform _transform in transform)
         {
-            _transform.gameObject.SetActive(!_transform.gameObject.activeSelf); 
+            if (_transform.gameObject != tutorialPane)
+            {
+                _transform.gameObject.SetActive(!_transform.gameObject.activeSelf); 
+            }
         }
     }
 }

--- a/JumpingJax/Assets/Scripts/UI/InGameUI.cs
+++ b/JumpingJax/Assets/Scripts/UI/InGameUI.cs
@@ -40,6 +40,11 @@ public class InGameUI : MonoBehaviour
         {
             LoadNextTutorial();
         }
+        else if (Input.GetKey(PlayerConstants.Modifier) && Input.GetKeyUp(PlayerConstants.InGameUI))
+        {
+            ToggleInGameUI(); 
+        }
+        
 
     }
 
@@ -54,6 +59,14 @@ public class InGameUI : MonoBehaviour
         else
         {
             tutorialPane.SetActive(false);
+        }
+    }
+
+    private void ToggleInGameUI()
+    {
+        foreach (Transform _transform in transform)
+        {
+            _transform.gameObject.SetActive(!_transform.gameObject.activeSelf); 
         }
     }
 }


### PR DESCRIPTION
Alt-Z key combo toggles on/off the InGameUI objects (time taken, fps, speed, and crosshair).

I'm assuming you don't want this to extend to the tutorial display, since it is not always visible by default.